### PR TITLE
Add admin management screens and dark-theme settings

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="/src/Main.tsx"></script>
   </body>
 </html>

--- a/frontend/src/Main.tsx
+++ b/frontend/src/Main.tsx
@@ -4,11 +4,14 @@ import './index.css'
 
 import RoutesApp from './routes/routes.tsx'
 import { AuthProvider } from './hooks/AuthContext.tsx'
+import { ThemeProvider } from './hooks/ThemeContext.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <AuthProvider>
-      <RoutesApp />
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <RoutesApp />
+      </AuthProvider>
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/frontend/src/hooks/AuthContext.tsx
+++ b/frontend/src/hooks/AuthContext.tsx
@@ -28,8 +28,19 @@ export function AuthProvider({ children}: {children: React.ReactNode}){
         localStorage.removeItem('user')
     }
 
+    function updateUser(userData: Partial<User>){
+        setUser((currentUser) => {
+            if(!currentUser){
+                return currentUser
+            }
+            const updatedUser = { ...currentUser, ...userData }
+            localStorage.setItem('user', JSON.stringify(updatedUser))
+            return updatedUser
+        })
+    }
+
     return(
-        <AuthContext.Provider value={{user, token, login, logout}}>
+        <AuthContext.Provider value={{user, token, login, logout, updateUser}}>
             {children}
         </AuthContext.Provider>
     )

--- a/frontend/src/hooks/ThemeContext.tsx
+++ b/frontend/src/hooks/ThemeContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react"
+
+type Theme = "dark" | "light"
+
+interface ThemeContextValue {
+    theme: Theme
+    setTheme: (theme: Theme) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+    theme: "dark",
+    setTheme: () => undefined
+})
+
+const getInitialTheme = (): Theme => {
+    const storedTheme = localStorage.getItem("theme") as Theme | null
+    if (storedTheme === "light" || storedTheme === "dark") {
+        return storedTheme
+    }
+    return "dark"
+}
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+    const [theme, setTheme] = useState<Theme>(getInitialTheme)
+
+    useEffect(() => {
+        document.documentElement.setAttribute("data-theme", theme)
+        document.documentElement.style.colorScheme = theme
+        localStorage.setItem("theme", theme)
+    }, [theme])
+
+    const value = useMemo(() => ({ theme, setTheme }), [theme])
+
+    return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export const useTheme = () => useContext(ThemeContext)

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,10 +15,6 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;

--- a/frontend/src/pages/Auth/AdminCities.tsx
+++ b/frontend/src/pages/Auth/AdminCities.tsx
@@ -1,0 +1,322 @@
+import { FormEvent, useMemo, useState } from "react"
+import * as Icons from "@mui/icons-material"
+import Sidebar from "../../components/Sidebar"
+import "../../styles/adminManagement.css"
+
+type CityStatus = "Ativa" | "Em manutenção"
+
+type City = {
+    id: number
+    name: string
+    country: string
+    state: string
+    hub: string
+    status: CityStatus
+    updatedAt: string
+}
+
+const initialCities: City[] = [
+    {
+        id: 1,
+        name: "São Paulo",
+        country: "Brasil",
+        state: "SP",
+        hub: "GRU",
+        status: "Ativa",
+        updatedAt: "12/09/2024"
+    },
+    {
+        id: 2,
+        name: "Lisboa",
+        country: "Portugal",
+        state: "LX",
+        hub: "LIS",
+        status: "Ativa",
+        updatedAt: "04/09/2024"
+    },
+    {
+        id: 3,
+        name: "Bogotá",
+        country: "Colômbia",
+        state: "DC",
+        hub: "BOG",
+        status: "Em manutenção",
+        updatedAt: "30/08/2024"
+    }
+]
+
+type FilterField = "name" | "country" | "hub" | "status"
+
+function AdminCities(){
+    const [sidebarOpen, setSidebarOpen] = useState(true)
+    const [cities, setCities] = useState<City[]>(initialCities)
+    const [searchTerm, setSearchTerm] = useState("")
+    const [filterField, setFilterField] = useState<FilterField>("name")
+    const [editingId, setEditingId] = useState<number | null>(null)
+    const [formState, setFormState] = useState<Omit<City, "id" | "updatedAt">>({
+        name: "",
+        country: "",
+        state: "",
+        hub: "",
+        status: "Ativa"
+    })
+
+    const filteredCities = useMemo(() => {
+        const normalizedSearch = searchTerm.trim().toLowerCase()
+        if (!normalizedSearch) {
+            return cities
+        }
+        return cities.filter((city) => {
+            const value = city[filterField]
+            return value.toLowerCase().includes(normalizedSearch)
+        })
+    }, [cities, filterField, searchTerm])
+
+    const resetForm = () => {
+        setFormState({
+            name: "",
+            country: "",
+            state: "",
+            hub: "",
+            status: "Ativa"
+        })
+        setEditingId(null)
+    }
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        if (!formState.name || !formState.country || !formState.hub) {
+            return
+        }
+
+        if (editingId) {
+            setCities((current) =>
+                current.map((city) =>
+                    city.id === editingId
+                        ? {
+                            ...city,
+                            ...formState,
+                            updatedAt: new Date().toLocaleDateString("pt-BR")
+                        }
+                        : city
+                )
+            )
+        } else {
+            const newCity: City = {
+                id: Math.max(0, ...cities.map((city) => city.id)) + 1,
+                updatedAt: new Date().toLocaleDateString("pt-BR"),
+                ...formState
+            }
+            setCities((current) => [...current, newCity])
+        }
+        resetForm()
+    }
+
+    const handleEdit = (city: City) => {
+        setEditingId(city.id)
+        setFormState({
+            name: city.name,
+            country: city.country,
+            state: city.state,
+            hub: city.hub,
+            status: city.status
+        })
+    }
+
+    const handleDelete = (cityId: number) => {
+        setCities((current) => current.filter((city) => city.id !== cityId))
+        if (editingId === cityId) {
+            resetForm()
+        }
+    }
+
+    return(
+        <div className={`admin-layout admin-management ${sidebarOpen ? "sidebar-open" : "sidebar-closed"}`}>
+            <Sidebar isOpen={sidebarOpen} onToggle={setSidebarOpen}/>
+            <main className="admin-main">
+                <header className="admin-management-topbar">
+                    <div>
+                        <p className="admin-kicker">Módulo Administrativo</p>
+                        <h1>Gerenciar cidades</h1>
+                        <p className="admin-subtitle">
+                            Controle as cidades atendidas, hubs estratégicos e status de operação.
+                        </p>
+                    </div>
+                    <button className="admin-cta" type="button" onClick={resetForm}>
+                        <Icons.AddCircleOutline/>
+                        Nova cidade
+                    </button>
+                </header>
+
+                <section className="admin-management-toolbar">
+                    <div className="admin-management-search">
+                        <Icons.Search/>
+                        <input
+                            type="text"
+                            placeholder="Buscar cidade, hub ou status"
+                            value={searchTerm}
+                            onChange={(event) => setSearchTerm(event.target.value)}
+                        />
+                    </div>
+                    <div className="admin-management-filter">
+                        <label htmlFor="city-filter">Filtrar por</label>
+                        <select
+                            id="city-filter"
+                            value={filterField}
+                            onChange={(event) => setFilterField(event.target.value as FilterField)}
+                        >
+                            <option value="name">Nome</option>
+                            <option value="country">País</option>
+                            <option value="hub">Hub</option>
+                            <option value="status">Status</option>
+                        </select>
+                    </div>
+                </section>
+
+                <section className="admin-management-grid">
+                    <div className="admin-management-panel">
+                        <h2>Informações da cidade</h2>
+                        <form className="admin-management-form" onSubmit={handleSubmit}>
+                            <div>
+                                <label htmlFor="city-name">Nome</label>
+                                <input
+                                    id="city-name"
+                                    value={formState.name}
+                                    onChange={(event) => setFormState({ ...formState, name: event.target.value })}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="city-country">País</label>
+                                <input
+                                    id="city-country"
+                                    value={formState.country}
+                                    onChange={(event) => setFormState({ ...formState, country: event.target.value })}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="city-state">UF/Região</label>
+                                <input
+                                    id="city-state"
+                                    value={formState.state}
+                                    onChange={(event) => setFormState({ ...formState, state: event.target.value })}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="city-hub">Hub principal</label>
+                                <input
+                                    id="city-hub"
+                                    value={formState.hub}
+                                    onChange={(event) => setFormState({ ...formState, hub: event.target.value })}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="city-status">Status</label>
+                                <select
+                                    id="city-status"
+                                    value={formState.status}
+                                    onChange={(event) =>
+                                        setFormState({ ...formState, status: event.target.value as CityStatus })
+                                    }
+                                >
+                                    <option value="Ativa">Ativa</option>
+                                    <option value="Em manutenção">Em manutenção</option>
+                                </select>
+                            </div>
+                            <div className="admin-management-form-actions">
+                                <button className="admin-cta" type="submit">
+                                    <Icons.SaveOutlined/>
+                                    {editingId ? "Atualizar" : "Adicionar"}
+                                </button>
+                                {editingId && (
+                                    <button className="admin-cta secondary" type="button" onClick={resetForm}>
+                                        Cancelar
+                                    </button>
+                                )}
+                            </div>
+                        </form>
+                    </div>
+
+                    <div className="admin-management-panel">
+                        <h2>Lista de cidades</h2>
+                        <table className="admin-management-table">
+                            <thead>
+                                <tr>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "name" ? "is-active" : ""}
+                                            onClick={() => setFilterField("name")}
+                                        >
+                                            Cidade
+                                        </button>
+                                    </th>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "country" ? "is-active" : ""}
+                                            onClick={() => setFilterField("country")}
+                                        >
+                                            País
+                                        </button>
+                                    </th>
+                                    <th>UF</th>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "hub" ? "is-active" : ""}
+                                            onClick={() => setFilterField("hub")}
+                                        >
+                                            Hub
+                                        </button>
+                                    </th>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "status" ? "is-active" : ""}
+                                            onClick={() => setFilterField("status")}
+                                        >
+                                            Status
+                                        </button>
+                                    </th>
+                                    <th>Atualizado</th>
+                                    <th>Ações</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {filteredCities.map((city) => (
+                                    <tr key={city.id}>
+                                        <td>{city.name}</td>
+                                        <td>{city.country}</td>
+                                        <td>{city.state}</td>
+                                        <td>{city.hub}</td>
+                                        <td>
+                                            <span className={`admin-pill ${city.status === "Ativa" ? "success" : "warning"}`}>
+                                                {city.status}
+                                            </span>
+                                        </td>
+                                        <td>{city.updatedAt}</td>
+                                        <td>
+                                            <div className="admin-table-actions">
+                                                <button type="button" onClick={() => handleEdit(city)}>
+                                                    <Icons.EditOutlined/>
+                                                </button>
+                                                <button type="button" onClick={() => handleDelete(city.id)}>
+                                                    <Icons.DeleteOutline/>
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                        {filteredCities.length === 0 && (
+                            <p className="admin-management-empty">Nenhuma cidade encontrada com o filtro atual.</p>
+                        )}
+                    </div>
+                </section>
+            </main>
+        </div>
+    )
+}
+
+export default AdminCities

--- a/frontend/src/pages/Auth/AdminDashboard.tsx
+++ b/frontend/src/pages/Auth/AdminDashboard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react"
 import * as Icons from "@mui/icons-material"
 import Sidebar from "../../components/Sidebar"
 import api from "../../Server"
+import { useNavigate } from "react-router-dom"
 
 type City = {
     id: number
@@ -50,6 +51,7 @@ const sortTimeValue = (value: string) => {
 
 function AdminDashboard(){
     const [sidebarOpen, setSidebarOpen] = useState(true)
+    const navigate = useNavigate()
     const [metrics, setMetrics] = useState<MetricState>({
         trips: 0,
         routes: 0,
@@ -194,19 +196,19 @@ function AdminDashboard(){
                     <div className="admin-panel">
                         <h3>Atalhos rápidos</h3>
                         <div className="admin-shortcuts">
-                            <button>
+                            <button type="button" onClick={() => navigate("/admin/voos")}>
                                 <Icons.ConnectingAirports/>
                                 Gerenciar voos
                             </button>
-                            <button>
+                            <button type="button" onClick={() => navigate("/admin/cidades")}>
                                 <Icons.Apartment/>
                                 Cidades e hubs
                             </button>
-                            <button>
+                            <button type="button" onClick={() => navigate("/admin/usuarios")}>
                                 <Icons.PersonOutline/>
                                 Usuários e permissões
                             </button>
-                            <button>
+                            <button type="button" onClick={() => navigate("/admin/configuracoes")}>
                                 <Icons.SettingsOutlined/>
                                 Configurações
                             </button>

--- a/frontend/src/pages/Auth/AdminRoutes.tsx
+++ b/frontend/src/pages/Auth/AdminRoutes.tsx
@@ -1,0 +1,324 @@
+import { FormEvent, useMemo, useState } from "react"
+import * as Icons from "@mui/icons-material"
+import Sidebar from "../../components/Sidebar"
+import "../../styles/adminManagement.css"
+
+type RouteStatus = "Ativa" | "Suspensa"
+
+type Route = {
+    id: number
+    name: string
+    origin: string
+    destination: string
+    distance: string
+    duration: string
+    status: RouteStatus
+}
+
+const initialRoutes: Route[] = [
+    {
+        id: 1,
+        name: "Rota Atlântica",
+        origin: "São Paulo",
+        destination: "Lisboa",
+        distance: "7.900 km",
+        duration: "9h 50m",
+        status: "Ativa"
+    },
+    {
+        id: 2,
+        name: "Rota Andina",
+        origin: "Bogotá",
+        destination: "Lima",
+        distance: "1.880 km",
+        duration: "3h 20m",
+        status: "Suspensa"
+    },
+    {
+        id: 3,
+        name: "Rota Polar",
+        origin: "Toronto",
+        destination: "Reykjavík",
+        distance: "3.600 km",
+        duration: "5h 05m",
+        status: "Ativa"
+    }
+]
+
+type FilterField = "name" | "origin" | "destination" | "status"
+
+function AdminRoutes(){
+    const [sidebarOpen, setSidebarOpen] = useState(true)
+    const [routes, setRoutes] = useState<Route[]>(initialRoutes)
+    const [searchTerm, setSearchTerm] = useState("")
+    const [filterField, setFilterField] = useState<FilterField>("name")
+    const [editingId, setEditingId] = useState<number | null>(null)
+    const [formState, setFormState] = useState<Omit<Route, "id">>({
+        name: "",
+        origin: "",
+        destination: "",
+        distance: "",
+        duration: "",
+        status: "Ativa"
+    })
+
+    const filteredRoutes = useMemo(() => {
+        const normalizedSearch = searchTerm.trim().toLowerCase()
+        if (!normalizedSearch) {
+            return routes
+        }
+        return routes.filter((route) => {
+            const value = route[filterField]
+            return value.toLowerCase().includes(normalizedSearch)
+        })
+    }, [routes, filterField, searchTerm])
+
+    const resetForm = () => {
+        setFormState({
+            name: "",
+            origin: "",
+            destination: "",
+            distance: "",
+            duration: "",
+            status: "Ativa"
+        })
+        setEditingId(null)
+    }
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        if (!formState.name || !formState.origin || !formState.destination) {
+            return
+        }
+
+        if (editingId) {
+            setRoutes((current) =>
+                current.map((route) => (route.id === editingId ? { ...route, ...formState } : route))
+            )
+        } else {
+            const newRoute: Route = {
+                id: Math.max(0, ...routes.map((route) => route.id)) + 1,
+                ...formState
+            }
+            setRoutes((current) => [...current, newRoute])
+        }
+        resetForm()
+    }
+
+    const handleEdit = (route: Route) => {
+        setEditingId(route.id)
+        setFormState({
+            name: route.name,
+            origin: route.origin,
+            destination: route.destination,
+            distance: route.distance,
+            duration: route.duration,
+            status: route.status
+        })
+    }
+
+    const handleDelete = (routeId: number) => {
+        setRoutes((current) => current.filter((route) => route.id !== routeId))
+        if (editingId === routeId) {
+            resetForm()
+        }
+    }
+
+    return(
+        <div className={`admin-layout admin-management ${sidebarOpen ? "sidebar-open" : "sidebar-closed"}`}>
+            <Sidebar isOpen={sidebarOpen} onToggle={setSidebarOpen}/>
+            <main className="admin-main">
+                <header className="admin-management-topbar">
+                    <div>
+                        <p className="admin-kicker">Módulo Administrativo</p>
+                        <h1>Gerenciar rotas</h1>
+                        <p className="admin-subtitle">
+                            Cadastre, edite e acompanhe o status das rotas operacionais.
+                        </p>
+                    </div>
+                    <button className="admin-cta" type="button" onClick={resetForm}>
+                        <Icons.AddCircleOutline/>
+                        Nova rota
+                    </button>
+                </header>
+
+                <section className="admin-management-toolbar">
+                    <div className="admin-management-search">
+                        <Icons.Search/>
+                        <input
+                            type="text"
+                            placeholder="Buscar rota, origem, destino ou status"
+                            value={searchTerm}
+                            onChange={(event) => setSearchTerm(event.target.value)}
+                        />
+                    </div>
+                    <div className="admin-management-filter">
+                        <label htmlFor="route-filter">Filtrar por</label>
+                        <select
+                            id="route-filter"
+                            value={filterField}
+                            onChange={(event) => setFilterField(event.target.value as FilterField)}
+                        >
+                            <option value="name">Nome da rota</option>
+                            <option value="origin">Origem</option>
+                            <option value="destination">Destino</option>
+                            <option value="status">Status</option>
+                        </select>
+                    </div>
+                </section>
+
+                <section className="admin-management-grid">
+                    <div className="admin-management-panel">
+                        <h2>Dados da rota</h2>
+                        <form className="admin-management-form" onSubmit={handleSubmit}>
+                            <div>
+                                <label htmlFor="route-name">Nome da rota</label>
+                                <input
+                                    id="route-name"
+                                    value={formState.name}
+                                    onChange={(event) => setFormState({ ...formState, name: event.target.value })}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="route-origin">Origem</label>
+                                <input
+                                    id="route-origin"
+                                    value={formState.origin}
+                                    onChange={(event) => setFormState({ ...formState, origin: event.target.value })}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="route-destination">Destino</label>
+                                <input
+                                    id="route-destination"
+                                    value={formState.destination}
+                                    onChange={(event) => setFormState({ ...formState, destination: event.target.value })}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="route-distance">Distância</label>
+                                <input
+                                    id="route-distance"
+                                    value={formState.distance}
+                                    onChange={(event) => setFormState({ ...formState, distance: event.target.value })}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="route-duration">Duração</label>
+                                <input
+                                    id="route-duration"
+                                    value={formState.duration}
+                                    onChange={(event) => setFormState({ ...formState, duration: event.target.value })}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="route-status">Status</label>
+                                <select
+                                    id="route-status"
+                                    value={formState.status}
+                                    onChange={(event) =>
+                                        setFormState({ ...formState, status: event.target.value as RouteStatus })
+                                    }
+                                >
+                                    <option value="Ativa">Ativa</option>
+                                    <option value="Suspensa">Suspensa</option>
+                                </select>
+                            </div>
+                            <div className="admin-management-form-actions">
+                                <button className="admin-cta" type="submit">
+                                    <Icons.SaveOutlined/>
+                                    {editingId ? "Atualizar" : "Adicionar"}
+                                </button>
+                                {editingId && (
+                                    <button className="admin-cta secondary" type="button" onClick={resetForm}>
+                                        Cancelar
+                                    </button>
+                                )}
+                            </div>
+                        </form>
+                    </div>
+
+                    <div className="admin-management-panel">
+                        <h2>Rotas cadastradas</h2>
+                        <table className="admin-management-table">
+                            <thead>
+                                <tr>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "name" ? "is-active" : ""}
+                                            onClick={() => setFilterField("name")}
+                                        >
+                                            Rota
+                                        </button>
+                                    </th>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "origin" ? "is-active" : ""}
+                                            onClick={() => setFilterField("origin")}
+                                        >
+                                            Origem
+                                        </button>
+                                    </th>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "destination" ? "is-active" : ""}
+                                            onClick={() => setFilterField("destination")}
+                                        >
+                                            Destino
+                                        </button>
+                                    </th>
+                                    <th>Distância</th>
+                                    <th>Duração</th>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "status" ? "is-active" : ""}
+                                            onClick={() => setFilterField("status")}
+                                        >
+                                            Status
+                                        </button>
+                                    </th>
+                                    <th>Ações</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {filteredRoutes.map((route) => (
+                                    <tr key={route.id}>
+                                        <td>{route.name}</td>
+                                        <td>{route.origin}</td>
+                                        <td>{route.destination}</td>
+                                        <td>{route.distance}</td>
+                                        <td>{route.duration}</td>
+                                        <td>
+                                            <span className={`admin-pill ${route.status === "Ativa" ? "success" : "warning"}`}>
+                                                {route.status}
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <div className="admin-table-actions">
+                                                <button type="button" onClick={() => handleEdit(route)}>
+                                                    <Icons.EditOutlined/>
+                                                </button>
+                                                <button type="button" onClick={() => handleDelete(route.id)}>
+                                                    <Icons.DeleteOutline/>
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                        {filteredRoutes.length === 0 && (
+                            <p className="admin-management-empty">Nenhuma rota encontrada com o filtro atual.</p>
+                        )}
+                    </div>
+                </section>
+            </main>
+        </div>
+    )
+}
+
+export default AdminRoutes

--- a/frontend/src/pages/Auth/AdminSettings.tsx
+++ b/frontend/src/pages/Auth/AdminSettings.tsx
@@ -1,0 +1,177 @@
+import { FormEvent, useState } from "react"
+import * as Icons from "@mui/icons-material"
+import Sidebar from "../../components/Sidebar"
+import { useAuth } from "../../services/authContext"
+import { useTheme } from "../../hooks/ThemeContext"
+import "../../styles/adminSettings.css"
+
+function AdminSettings(){
+    const [sidebarOpen, setSidebarOpen] = useState(true)
+    const { user, updateUser } = useAuth()
+    const { theme, setTheme } = useTheme()
+    const [name, setName] = useState(user?.name ?? "")
+    const [email, setEmail] = useState(user?.email ?? "")
+    const [avatarPath, setAvatarPath] = useState(user?.avatarPath ?? "")
+    const [language, setLanguage] = useState("Português (BR)")
+    const [currency, setCurrency] = useState("BRL")
+    const [notifications, setNotifications] = useState(true)
+    const [autoReports, setAutoReports] = useState(false)
+
+    const handleProfileSave = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        updateUser({ name, email, avatarPath })
+    }
+
+    return(
+        <div className={`admin-layout admin-settings ${sidebarOpen ? "sidebar-open" : "sidebar-closed"}`}>
+            <Sidebar isOpen={sidebarOpen} onToggle={setSidebarOpen}/>
+            <main className="admin-main">
+                <header className="admin-settings-topbar">
+                    <div>
+                        <p className="admin-kicker">Módulo Administrativo</p>
+                        <h1>Configurações</h1>
+                        <p className="admin-subtitle">Personalize sua conta e ajuste preferências do painel.</p>
+                    </div>
+                </header>
+
+                <section className="admin-settings-grid">
+                    <div className="admin-settings-card">
+                        <div className="admin-settings-card-header">
+                            <Icons.PaletteOutlined/>
+                            <div>
+                                <h2>Tema</h2>
+                                <p>Escolha como deseja visualizar o painel.</p>
+                            </div>
+                        </div>
+                        <div className="admin-settings-theme-toggle">
+                            <button
+                                type="button"
+                                className={theme === "dark" ? "is-active" : ""}
+                                onClick={() => setTheme("dark")}
+                            >
+                                <Icons.DarkModeOutlined/>
+                                Modo escuro
+                            </button>
+                            <button
+                                type="button"
+                                className={theme === "light" ? "is-active" : ""}
+                                onClick={() => setTheme("light")}
+                            >
+                                <Icons.LightModeOutlined/>
+                                Modo claro
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="admin-settings-card">
+                        <div className="admin-settings-card-header">
+                            <Icons.PersonOutline/>
+                            <div>
+                                <h2>Dados do usuário</h2>
+                                <p>Atualize nome, e-mail e foto de perfil.</p>
+                            </div>
+                        </div>
+                        <form className="admin-settings-form" onSubmit={handleProfileSave}>
+                            <label htmlFor="settings-name">Nome</label>
+                            <input
+                                id="settings-name"
+                                value={name}
+                                onChange={(event) => setName(event.target.value)}
+                            />
+                            <label htmlFor="settings-email">E-mail</label>
+                            <input
+                                id="settings-email"
+                                type="email"
+                                value={email}
+                                onChange={(event) => setEmail(event.target.value)}
+                            />
+                            <label htmlFor="settings-avatar">Foto do usuário (URL)</label>
+                            <input
+                                id="settings-avatar"
+                                value={avatarPath}
+                                onChange={(event) => setAvatarPath(event.target.value)}
+                            />
+                            <div className="admin-settings-avatar-preview">
+                                {avatarPath ? (
+                                    <img src={avatarPath} alt="Prévia do avatar" />
+                                ) : (
+                                    <div className="admin-settings-avatar-placeholder">
+                                        <Icons.Person/>
+                                    </div>
+                                )}
+                                <div>
+                                    <h3>Pré-visualização</h3>
+                                    <p>Atualize a URL para trocar a imagem do perfil.</p>
+                                </div>
+                            </div>
+                            <button className="admin-cta" type="submit">
+                                <Icons.SaveOutlined/>
+                                Salvar alterações
+                            </button>
+                        </form>
+                    </div>
+
+                    <div className="admin-settings-card">
+                        <div className="admin-settings-card-header">
+                            <Icons.SettingsOutlined/>
+                            <div>
+                                <h2>Configurações padrão</h2>
+                                <p>Defina parâmetros para novas operações administrativas.</p>
+                            </div>
+                        </div>
+                        <div className="admin-settings-form">
+                            <label htmlFor="settings-language">Idioma padrão</label>
+                            <select
+                                id="settings-language"
+                                value={language}
+                                onChange={(event) => setLanguage(event.target.value)}
+                            >
+                                <option>Português (BR)</option>
+                                <option>Inglês (EN)</option>
+                                <option>Espanhol (ES)</option>
+                            </select>
+                            <label htmlFor="settings-currency">Moeda padrão</label>
+                            <select
+                                id="settings-currency"
+                                value={currency}
+                                onChange={(event) => setCurrency(event.target.value)}
+                            >
+                                <option value="BRL">Real (BRL)</option>
+                                <option value="USD">Dólar (USD)</option>
+                                <option value="EUR">Euro (EUR)</option>
+                            </select>
+                            <div className="admin-settings-toggle">
+                                <div>
+                                    <h3>Notificações de status</h3>
+                                    <p>Receba alertas sobre mudanças críticas.</p>
+                                </div>
+                                <button
+                                    type="button"
+                                    className={notifications ? "is-active" : ""}
+                                    onClick={() => setNotifications((current) => !current)}
+                                >
+                                    {notifications ? "Ativo" : "Inativo"}
+                                </button>
+                            </div>
+                            <div className="admin-settings-toggle">
+                                <div>
+                                    <h3>Relatórios automáticos</h3>
+                                    <p>Envio diário para o time de gestão.</p>
+                                </div>
+                                <button
+                                    type="button"
+                                    className={autoReports ? "is-active" : ""}
+                                    onClick={() => setAutoReports((current) => !current)}
+                                >
+                                    {autoReports ? "Ativo" : "Inativo"}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </main>
+        </div>
+    )
+}
+
+export default AdminSettings

--- a/frontend/src/pages/Auth/AdminUsers.tsx
+++ b/frontend/src/pages/Auth/AdminUsers.tsx
@@ -1,0 +1,312 @@
+import { FormEvent, useMemo, useState } from "react"
+import * as Icons from "@mui/icons-material"
+import Sidebar from "../../components/Sidebar"
+import "../../styles/adminManagement.css"
+
+type UserRole = "Administrador" | "Operador" | "Analista"
+
+type UserStatus = "Ativo" | "Bloqueado"
+
+type ManagedUser = {
+    id: number
+    name: string
+    email: string
+    role: UserRole
+    status: UserStatus
+    lastAccess: string
+}
+
+const initialUsers: ManagedUser[] = [
+    {
+        id: 1,
+        name: "Marina Costa",
+        email: "marina.costa@cryas.com",
+        role: "Administrador",
+        status: "Ativo",
+        lastAccess: "Hoje às 09:32"
+    },
+    {
+        id: 2,
+        name: "Tiago Souza",
+        email: "tiago.souza@cryas.com",
+        role: "Operador",
+        status: "Ativo",
+        lastAccess: "Ontem às 18:10"
+    },
+    {
+        id: 3,
+        name: "Laura Díaz",
+        email: "laura.diaz@cryas.com",
+        role: "Analista",
+        status: "Bloqueado",
+        lastAccess: "12/09/2024"
+    }
+]
+
+type FilterField = "name" | "email" | "role" | "status"
+
+function AdminUsers(){
+    const [sidebarOpen, setSidebarOpen] = useState(true)
+    const [users, setUsers] = useState<ManagedUser[]>(initialUsers)
+    const [searchTerm, setSearchTerm] = useState("")
+    const [filterField, setFilterField] = useState<FilterField>("name")
+    const [editingId, setEditingId] = useState<number | null>(null)
+    const [formState, setFormState] = useState<Omit<ManagedUser, "id" | "lastAccess">>({
+        name: "",
+        email: "",
+        role: "Operador",
+        status: "Ativo"
+    })
+
+    const filteredUsers = useMemo(() => {
+        const normalizedSearch = searchTerm.trim().toLowerCase()
+        if (!normalizedSearch) {
+            return users
+        }
+        return users.filter((user) => {
+            const value = user[filterField]
+            return value.toLowerCase().includes(normalizedSearch)
+        })
+    }, [users, filterField, searchTerm])
+
+    const resetForm = () => {
+        setFormState({
+            name: "",
+            email: "",
+            role: "Operador",
+            status: "Ativo"
+        })
+        setEditingId(null)
+    }
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        if (!formState.name || !formState.email) {
+            return
+        }
+
+        if (editingId) {
+            setUsers((current) =>
+                current.map((user) =>
+                    user.id === editingId
+                        ? {
+                            ...user,
+                            ...formState,
+                            lastAccess: "Atualizado agora"
+                        }
+                        : user
+                )
+            )
+        } else {
+            const newUser: ManagedUser = {
+                id: Math.max(0, ...users.map((user) => user.id)) + 1,
+                lastAccess: "Criado agora",
+                ...formState
+            }
+            setUsers((current) => [...current, newUser])
+        }
+        resetForm()
+    }
+
+    const handleEdit = (user: ManagedUser) => {
+        setEditingId(user.id)
+        setFormState({
+            name: user.name,
+            email: user.email,
+            role: user.role,
+            status: user.status
+        })
+    }
+
+    const handleDelete = (userId: number) => {
+        setUsers((current) => current.filter((user) => user.id !== userId))
+        if (editingId === userId) {
+            resetForm()
+        }
+    }
+
+    return(
+        <div className={`admin-layout admin-management ${sidebarOpen ? "sidebar-open" : "sidebar-closed"}`}>
+            <Sidebar isOpen={sidebarOpen} onToggle={setSidebarOpen}/>
+            <main className="admin-main">
+                <header className="admin-management-topbar">
+                    <div>
+                        <p className="admin-kicker">Módulo Administrativo</p>
+                        <h1>Gerenciar usuários</h1>
+                        <p className="admin-subtitle">
+                            Administre permissões, roles e status dos usuários internos.
+                        </p>
+                    </div>
+                    <button className="admin-cta" type="button" onClick={resetForm}>
+                        <Icons.AddCircleOutline/>
+                        Novo usuário
+                    </button>
+                </header>
+
+                <section className="admin-management-toolbar">
+                    <div className="admin-management-search">
+                        <Icons.Search/>
+                        <input
+                            type="text"
+                            placeholder="Buscar por usuário, email ou status"
+                            value={searchTerm}
+                            onChange={(event) => setSearchTerm(event.target.value)}
+                        />
+                    </div>
+                    <div className="admin-management-filter">
+                        <label htmlFor="user-filter">Filtrar por</label>
+                        <select
+                            id="user-filter"
+                            value={filterField}
+                            onChange={(event) => setFilterField(event.target.value as FilterField)}
+                        >
+                            <option value="name">Nome</option>
+                            <option value="email">E-mail</option>
+                            <option value="role">Perfil</option>
+                            <option value="status">Status</option>
+                        </select>
+                    </div>
+                </section>
+
+                <section className="admin-management-grid">
+                    <div className="admin-management-panel">
+                        <h2>Dados do usuário</h2>
+                        <form className="admin-management-form" onSubmit={handleSubmit}>
+                            <div>
+                                <label htmlFor="user-name">Nome completo</label>
+                                <input
+                                    id="user-name"
+                                    value={formState.name}
+                                    onChange={(event) => setFormState({ ...formState, name: event.target.value })}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="user-email">E-mail</label>
+                                <input
+                                    id="user-email"
+                                    type="email"
+                                    value={formState.email}
+                                    onChange={(event) => setFormState({ ...formState, email: event.target.value })}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="user-role">Perfil</label>
+                                <select
+                                    id="user-role"
+                                    value={formState.role}
+                                    onChange={(event) => setFormState({ ...formState, role: event.target.value as UserRole })}
+                                >
+                                    <option value="Administrador">Administrador</option>
+                                    <option value="Operador">Operador</option>
+                                    <option value="Analista">Analista</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label htmlFor="user-status">Status</label>
+                                <select
+                                    id="user-status"
+                                    value={formState.status}
+                                    onChange={(event) =>
+                                        setFormState({ ...formState, status: event.target.value as UserStatus })
+                                    }
+                                >
+                                    <option value="Ativo">Ativo</option>
+                                    <option value="Bloqueado">Bloqueado</option>
+                                </select>
+                            </div>
+                            <div className="admin-management-form-actions">
+                                <button className="admin-cta" type="submit">
+                                    <Icons.SaveOutlined/>
+                                    {editingId ? "Atualizar" : "Adicionar"}
+                                </button>
+                                {editingId && (
+                                    <button className="admin-cta secondary" type="button" onClick={resetForm}>
+                                        Cancelar
+                                    </button>
+                                )}
+                            </div>
+                        </form>
+                    </div>
+
+                    <div className="admin-management-panel">
+                        <h2>Usuários cadastrados</h2>
+                        <table className="admin-management-table">
+                            <thead>
+                                <tr>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "name" ? "is-active" : ""}
+                                            onClick={() => setFilterField("name")}
+                                        >
+                                            Nome
+                                        </button>
+                                    </th>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "email" ? "is-active" : ""}
+                                            onClick={() => setFilterField("email")}
+                                        >
+                                            E-mail
+                                        </button>
+                                    </th>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "role" ? "is-active" : ""}
+                                            onClick={() => setFilterField("role")}
+                                        >
+                                            Perfil
+                                        </button>
+                                    </th>
+                                    <th>
+                                        <button
+                                            type="button"
+                                            className={filterField === "status" ? "is-active" : ""}
+                                            onClick={() => setFilterField("status")}
+                                        >
+                                            Status
+                                        </button>
+                                    </th>
+                                    <th>Último acesso</th>
+                                    <th>Ações</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {filteredUsers.map((user) => (
+                                    <tr key={user.id}>
+                                        <td>{user.name}</td>
+                                        <td>{user.email}</td>
+                                        <td>{user.role}</td>
+                                        <td>
+                                            <span className={`admin-pill ${user.status === "Ativo" ? "success" : "danger"}`}>
+                                                {user.status}
+                                            </span>
+                                        </td>
+                                        <td>{user.lastAccess}</td>
+                                        <td>
+                                            <div className="admin-table-actions">
+                                                <button type="button" onClick={() => handleEdit(user)}>
+                                                    <Icons.EditOutlined/>
+                                                </button>
+                                                <button type="button" onClick={() => handleDelete(user.id)}>
+                                                    <Icons.DeleteOutline/>
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                        {filteredUsers.length === 0 && (
+                            <p className="admin-management-empty">Nenhum usuário encontrado com o filtro atual.</p>
+                        )}
+                    </div>
+                </section>
+            </main>
+        </div>
+    )
+}
+
+export default AdminUsers

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -5,6 +5,10 @@ import LoginPage from "../pages/Auth/LoginPage"
 import RegisterPage from "../pages/Auth/RegisterPage"
 import AdminDashboard from "../pages/Auth/AdminDashboard"
 import AdminFlights from "../pages/Auth/AdminFlights"
+import AdminCities from "../pages/Auth/AdminCities"
+import AdminUsers from "../pages/Auth/AdminUsers"
+import AdminRoutes from "../pages/Auth/AdminRoutes"
+import AdminSettings from "../pages/Auth/AdminSettings"
 import { Navigate, Outlet } from "react-router-dom"
 
 const PrivateRoute = ({ isAuthenticated }: { isAuthenticated: boolean }) => {
@@ -21,6 +25,10 @@ const RoutesApp: React.FC = () => {
                 <Route path="/admin" element={<PrivateRoute isAuthenticated={true} />}>
                     <Route path="/admin" element={<AdminDashboard />} />
                     <Route path="/admin/voos" element={<AdminFlights />} />
+                    <Route path="/admin/cidades" element={<AdminCities />} />
+                    <Route path="/admin/usuarios" element={<AdminUsers />} />
+                    <Route path="/admin/rotas" element={<AdminRoutes />} />
+                    <Route path="/admin/configuracoes" element={<AdminSettings />} />
                 </Route>
             </Routes>
         </BrowserRouter>

--- a/frontend/src/services/authContext.ts
+++ b/frontend/src/services/authContext.ts
@@ -12,13 +12,15 @@ interface AuthContextData {
     token?: string | null;
     login: (userData: User, tokenValue: string) => void;
     logout: () => void;
+    updateUser: (userData: Partial<User>) => void;
 }
 
 export const AuthContext = createContext<AuthContextData>({
     user:null,
     token:null,
     login: () => {},
-    logout: () => {}
+    logout: () => {},
+    updateUser: () => {}
 })
 
 export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/styles/adminManagement.css
+++ b/frontend/src/styles/adminManagement.css
@@ -1,0 +1,210 @@
+.admin-layout.admin-management{
+    background-color: var(--color-background-secondary);
+    color: var(--color-text-primary);
+}
+
+.admin-management-topbar{
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.admin-management-toolbar{
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.admin-management-search{
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    padding: .65rem 1rem;
+    background-color: var(--color-background-primary);
+    border-radius: .75rem;
+    border: 1px solid var(--color-border);
+    min-width: 260px;
+    color: var(--color-text-secondary);
+}
+
+.admin-management-search input{
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--color-text-primary);
+    width: 100%;
+    font-size: .95rem;
+}
+
+.admin-management-filter{
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    color: var(--color-text-secondary);
+}
+
+.admin-management-filter select{
+    padding: .55rem .75rem;
+    border-radius: .6rem;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-background-primary);
+    color: var(--color-text-primary);
+}
+
+.admin-management-grid{
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.5rem;
+}
+
+.admin-management-panel{
+    background-color: var(--color-background-primary);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    border: 1px solid var(--color-border);
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.04);
+}
+
+.admin-management-panel h2{
+    margin-bottom: 1.25rem;
+}
+
+.admin-management-form{
+    display: grid;
+    gap: 1rem;
+}
+
+.admin-management-form label{
+    font-weight: 600;
+    margin-bottom: .35rem;
+    display: block;
+    color: var(--color-text-secondary);
+}
+
+.admin-management-form input,
+.admin-management-form select{
+    width: 100%;
+    padding: .65rem .8rem;
+    border-radius: .6rem;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-background-secondary);
+    color: var(--color-text-primary);
+}
+
+.admin-management-form-actions{
+    display: flex;
+    gap: .75rem;
+    flex-wrap: wrap;
+}
+
+.admin-management-table{
+    width: 100%;
+    border-collapse: collapse;
+    color: var(--color-text-primary);
+}
+
+.admin-management-table th,
+.admin-management-table td{
+    text-align: left;
+    padding: .85rem .75rem;
+    border-bottom: 1px solid var(--color-border);
+    font-size: .95rem;
+}
+
+.admin-management-table th{
+    color: var(--color-text-secondary);
+    font-weight: 600;
+}
+
+.admin-management-table th button{
+    border: none;
+    background: transparent;
+    color: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+}
+
+.admin-management-table th button.is-active{
+    color: var(--color-primary);
+}
+
+.admin-management-table tbody tr:hover{
+    background-color: var(--color-primary-light);
+}
+
+.admin-table-actions{
+    display: flex;
+    gap: .5rem;
+}
+
+.admin-table-actions button{
+    border: 1px solid var(--color-border);
+    background-color: transparent;
+    border-radius: .5rem;
+    padding: .35rem;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+}
+
+.admin-table-actions button:hover{
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.admin-pill{
+    display: inline-flex;
+    align-items: center;
+    padding: .2rem .6rem;
+    border-radius: 999px;
+    font-size: .8rem;
+    font-weight: 600;
+}
+
+.admin-pill.success{
+    background-color: rgba(72, 187, 120, 0.2);
+    color: var(--color-status-available);
+}
+
+.admin-pill.warning{
+    background-color: rgba(234, 182, 72, 0.2);
+    color: var(--color-dark-warning);
+}
+
+.admin-pill.danger{
+    background-color: rgba(229, 62, 62, 0.2);
+    color: var(--color-danger);
+}
+
+.admin-management-empty{
+    margin-top: 1rem;
+    color: var(--color-text-secondary);
+}
+
+@media (max-width: 960px){
+    .admin-management-topbar{
+        flex-direction: column;
+    }
+
+    .admin-management-toolbar{
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .admin-management-search{
+        width: 100%;
+    }
+
+    .admin-management-table{
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
+    }
+}

--- a/frontend/src/styles/adminSettings.css
+++ b/frontend/src/styles/adminSettings.css
@@ -1,0 +1,146 @@
+.admin-layout.admin-settings{
+    background-color: var(--color-background-secondary);
+    color: var(--color-text-primary);
+}
+
+.admin-settings-topbar{
+    margin-bottom: 2rem;
+}
+
+.admin-settings-grid{
+    display: grid;
+    gap: 1.5rem;
+}
+
+.admin-settings-card{
+    background-color: var(--color-background-primary);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    border: 1px solid var(--color-border);
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.04);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.admin-settings-card-header{
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.admin-settings-card-header svg{
+    font-size: 2rem;
+    color: var(--color-primary-dark);
+}
+
+.admin-settings-card-header p{
+    color: var(--color-text-secondary);
+}
+
+.admin-settings-theme-toggle{
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+}
+
+.admin-settings-theme-toggle button{
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    padding: .9rem 1rem;
+    border-radius: .75rem;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-background-secondary);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.admin-settings-theme-toggle button.is-active{
+    border-color: var(--color-primary);
+    background-color: var(--color-primary-light);
+    color: var(--color-primary-dark);
+}
+
+.admin-settings-form{
+    display: grid;
+    gap: 1rem;
+}
+
+.admin-settings-form label{
+    font-weight: 600;
+    color: var(--color-text-secondary);
+}
+
+.admin-settings-form input,
+.admin-settings-form select{
+    width: 100%;
+    padding: .65rem .8rem;
+    border-radius: .6rem;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-background-secondary);
+    color: var(--color-text-primary);
+}
+
+.admin-settings-avatar-preview{
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: .75rem;
+    border-radius: .75rem;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-background-secondary);
+}
+
+.admin-settings-avatar-preview img,
+.admin-settings-avatar-placeholder{
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    object-fit: cover;
+    display: grid;
+    place-items: center;
+    background-color: var(--color-primary-light);
+    color: var(--color-primary-dark);
+}
+
+.admin-settings-avatar-placeholder svg{
+    font-size: 2rem;
+}
+
+.admin-settings-toggle{
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: .75rem;
+    border-radius: .75rem;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-background-secondary);
+}
+
+.admin-settings-toggle p{
+    color: var(--color-text-secondary);
+}
+
+.admin-settings-toggle button{
+    border: 1px solid var(--color-border);
+    background-color: transparent;
+    border-radius: .6rem;
+    padding: .4rem .9rem;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    font-weight: 600;
+}
+
+.admin-settings-toggle button.is-active{
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+@media (max-width: 960px){
+    .admin-settings-avatar-preview{
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -73,6 +73,26 @@
   --color-dark-warning: #eab648;                /* Status alerta/atrasado */
 }
 
+:root[data-theme="dark"]{
+  --color-background-primary: var(--color-dark-background-primary);
+  --color-background-secondary: var(--color-dark-background-secondary);
+  --color-text-primary: var(--color-dark-text-main);
+  --color-text-secondary: var(--color-dark-text-muted);
+  --color-text-tertiary: #6b7b85;
+  --color-border: var(--color-dark-border);
+  --color-primary-light: rgba(35, 170, 255, 0.15);
+}
+
+:root[data-theme="light"]{
+  --color-background-primary: #FFFFFF;
+  --color-background-secondary: #F7FAFC;
+  --color-text-primary: #1A202C;
+  --color-text-secondary: #4A5568;
+  --color-text-tertiary: #718096;
+  --color-border: #E2E8F0;
+  --color-primary-light: #E6F7FF;
+}
+
 body{
     font-family: "Poppins", sans-serif;
     background-color: var(--color-background-primary);


### PR DESCRIPTION
### Motivation
- Provide an administrative settings screen to allow switching between dark/light themes, updating user name/email/avatar and configuring default behavior.
- Add management UIs for cities, users and routes with CRUD, searchable/filterable tables and inline action icons to match admin requirements.
- Make dark mode the default theme while allowing users to change it and persist the preference.

### Description
- Introduced a `ThemeContext` (`src/hooks/ThemeContext.tsx`) and wrapped the app with `ThemeProvider` in `Main.tsx` so theme is persisted via `localStorage` and applied with a `data-theme` attribute. 
- Added `AdminSettings` (`src/pages/Auth/AdminSettings.tsx`) to let users toggle theme, edit profile (name/email/avatar) and adjust default settings, plus related styles in `src/styles/adminSettings.css`.
- Implemented management pages `AdminCities`, `AdminUsers`, and `AdminRoutes` (`src/pages/Auth/*`) providing client-side CRUD forms, searchable inputs, selectable filter fields and table headers that apply filters, and action icons; shared styles added in `src/styles/adminManagement.css`.
- Wired new routes in `src/routes/routes.tsx`, added navigation shortcuts in `AdminDashboard.tsx`, and exposed an `updateUser` helper in the auth context (`src/services/authContext.ts` + `src/hooks/AuthContext.tsx`) to persist profile edits.
- Updated global theming variables in `src/styles/global.css` and removed the hardcoded colors in `src/index.css`; fixed Vite entry by adjusting `index.html` to load `src/Main.tsx`.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server reported Ready, which completed successfully. 
- Rendered the new settings page with an automated Playwright script (navigated to `/admin/configuracoes`) and captured a screenshot (`artifacts/admin-settings.png`), which completed successfully. 
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972166f7d3c832d932344d2f66160d7)